### PR TITLE
Fixed scratch org def file for API v52.0

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -13,11 +13,6 @@
         "lightningExperienceSettings": {
             "enableS1DesktopEnabled": true
         },
-        "securitySettings": {
-            "passwordPolicies": {
-                "enableSetPasswordInApi": true
-            }
-        },
         "mobileSettings": {
             "enableS1EncryptedStoragePref2": false
         }


### PR DESCRIPTION
Removed `enableSetPasswordInApi` property that is no longer compatible with API v52.0